### PR TITLE
Add Rust demo for DbotX trading API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target/
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "dbot_trade_demo"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1"
+reqwest = { version = "0.11", features = ["json", "rustls-tls"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["full"] }
+uuid = { version = "1", features = ["v4"] }

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# 2
+# DbotX Trade Demo
+
+This repository contains a minimal Rust example showing how to interact with the DbotX Data and Trade APIs.
+
+The program searches for an active pool by Solana token mint (CA) and submits a small IOC limit buy order using an API key.
+
+## Usage
+
+```bash
+cargo run -- <MINT>
+```
+
+Example:
+
+```bash
+cargo run -- QMaZd9LkqQexX2jz2LEir6N18PSYHm4pRjVTq5abonk
+```
+
+The code uses a temporary test key embedded in the source (`ckydkvw5urnw3shhjmz9wvuqmoqt36l2`). In real deployments, read credentials from environment variables and implement proper authentication/signing.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,83 @@
+use anyhow::Result;
+use reqwest::Client;
+use serde::Deserialize;
+
+const API_KEY: &str = "ckydkvw5urnw3shhjmz9wvuqmoqt36l2";
+
+#[derive(Debug, Deserialize)]
+struct PoolInfo {
+    #[serde(alias = "pair", alias = "pairId", alias = "id")]
+    pair_id: String,
+    #[serde(alias = "dex")]
+    dex: Option<String>,
+    #[serde(alias = "solReserve")]
+    sol_reserve: Option<f64>,
+    #[serde(alias = "tokenReserve")]
+    token_reserve: Option<f64>,
+    #[serde(alias = "tokenPrice")]
+    token_price: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OrderResp {
+    #[serde(alias = "orderId")]
+    order_id: String,
+    status: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 2 {
+        eprintln!("usage: {} <mint>", args[0]);
+        std::process::exit(1);
+    }
+    let mint = &args[1];
+
+    let client = Client::new();
+
+    // Search pools by mint/CA
+    let search_url = format!(
+        "https://api-data-v1.dbotx.com/kline/search?keyword={}",
+        mint
+    );
+    let pools: Vec<PoolInfo> = client
+        .get(&search_url)
+        .send()
+        .await?
+        .json()
+        .await?;
+    if pools.is_empty() {
+        eprintln!("no pool found for {}", mint);
+        return Ok(());
+    }
+    let pool = &pools[0];
+    println!("selected pool: {:?}", pool);
+
+    // Place a small IOC buy order using API key header auth
+    let order_url = "https://api-bot-v1.dbotx.com/trade/order";
+    let price = pool.token_price.unwrap_or(0.0) * 0.98;
+    let payload = serde_json::json!({
+        "chain": "solana",
+        "pair": pool.pair_id,
+        "side": "buy",
+        "type": "limit",
+        "price": price,
+        "size": "0.01",
+        "timeInForce": "IOC",
+        "slippageBps": 250,
+        "clientOrderId": uuid::Uuid::new_v4().to_string(),
+    });
+
+    let resp: OrderResp = client
+        .post(order_url)
+        .header("X-API-KEY", API_KEY)
+        .json(&payload)
+        .send()
+        .await?
+        .json()
+        .await?;
+    println!("order response: {:?}", resp);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add minimal Rust example that queries DbotX for pools and submits an IOC order
- document usage and embed temporary test key

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_689ae2074d608330a1fb1f01ad4a3cfd